### PR TITLE
Move viewmodel json write concern

### DIFF
--- a/app/controllers/ViewArrivalNotificationsController.scala
+++ b/app/controllers/ViewArrivalNotificationsController.scala
@@ -43,11 +43,6 @@ class ViewArrivalNotificationsController @Inject()(
     implicit request =>
       destinationConnector.getMovements().flatMap {
         movements =>
-          val urls = Json.obj(
-            "declareArrivalNotificationUrl" -> appConfig.declareArrivalNotificationUrl,
-            "homePageUrl"                   -> routes.IndexController.onPageLoad().url
-          )
-
           Future
             .sequence(movements.map(convertToViewMovements))
             .map(ViewArrivalMovements.apply)
@@ -55,7 +50,7 @@ class ViewArrivalNotificationsController @Inject()(
             .flatMap(
               json =>
                 renderer
-                  .render("viewArrivalNotifications.njk", json ++ urls)
+                  .render("viewArrivalNotifications.njk", json)
                   .map(Ok(_))
             )
       }

--- a/app/viewModels/ViewArrivalMovements.scala
+++ b/app/viewModels/ViewArrivalMovements.scala
@@ -21,6 +21,7 @@ import java.time.chrono.ChronoLocalDate
 import java.time.format.DateTimeFormatter
 
 import config.FrontendAppConfig
+import controllers.routes
 import play.api.libs.json.{JsObject, Json, OWrites}
 
 case class ViewArrivalMovements(
@@ -60,7 +61,8 @@ object ViewArrivalMovements {
       override def writes(o: ViewArrivalMovements): JsObject =
         Json.obj(
           "dataRows"                      -> o.dataRows,
-          "declareArrivalNotificationUrl" -> frontendAppConfig.declareArrivalNotificationUrl
+          "declareArrivalNotificationUrl" -> frontendAppConfig.declareArrivalNotificationUrl,
+          "homePageUrl"                   -> routes.IndexController.onPageLoad().url
         )
     }
 }

--- a/test/controllers/ViewArrivalNotificationsControllerSpec.scala
+++ b/test/controllers/ViewArrivalNotificationsControllerSpec.scala
@@ -145,7 +145,7 @@ class ViewArrivalNotificationsControllerSpec extends SpecBase with MockitoSugar 
       val jsonCaptorWithoutConfig: JsObject = jsonCaptor.getValue - configKey
 
       templateCaptor.getValue mustEqual "viewArrivalNotifications.njk"
-      jsonCaptorWithoutConfig mustBe expectedJson
+      jsonCaptorWithoutConfig mustBe expectedJson // TODO: To discuss. Should we check this here? The unit tests for ViewArrivalMovements cover the json serialization
 
       application.stop()
     }

--- a/test/generators/ModelGenerators.scala
+++ b/test/generators/ModelGenerators.scala
@@ -21,8 +21,9 @@ import java.time.{LocalDate, LocalTime, Year}
 import models._
 import models.referenceData.Movement
 import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen.listOfN
 import org.scalacheck.{Arbitrary, Gen}
-import viewModels.ViewMovement
+import viewModels.{ViewArrivalMovements, ViewMovement}
 
 trait ModelGenerators {
 
@@ -82,4 +83,11 @@ trait ModelGenerators {
         )
     }
   }
+
+  implicit val arbitraryViewArrivalMovements: Arbitrary[ViewArrivalMovements] =
+    Arbitrary {
+      for {
+        seqOfViewMovements <- listOfN(10, arbitrary[ViewMovement])
+      } yield ViewArrivalMovements(seqOfViewMovements)
+    }
 }


### PR DESCRIPTION
Move all viewmodel json write concern to the writes. This cleans up the controller logic and allows us to unit test this in the model.
