### PR TITLE
CTCTRADERS-2663: Fixing a11y issues

### DIFF
--- a/conf/messages.en
+++ b/conf/messages.en
@@ -83,13 +83,10 @@ viewArrivalNotifications.table.procedure   = Procedure
 viewArrivalNotifications.table.status      = Status
 viewArrivalNotifications.table.action      = Action
 viewArrivalNotifications.table.action.viewErrors              = View errors
-viewArrivalNotifications.table.action.viewErrors.hidden       = View errors for {0}
 viewArrivalNotifications.table.action.unloadingRemarks        = Make unloading remarks
-viewArrivalNotifications.table.action.unloadingRemarks.hidden = Make unloading remarks for {0}
 viewArrivalNotifications.table.action.viewHistory             = View history
-viewArrivalNotifications.table.action.viewHistory.hidden      = View history for {0}
 viewArrivalNotifications.table.action.viewPDF                 = Unloading Permission PDF
-viewArrivalNotifications.table.action.viewPDF.hidden          = Unloading Permission PDF for {0}
+viewArrivalNotifications.table.action.hidden                  = for {0}
 
 movement.search.title = Search by movement reference number
 movement.search.departure.title = Search by local reference number

--- a/conf/views/macros/showMovementsByDate.njk
+++ b/conf/views/macros/showMovementsByDate.njk
@@ -18,20 +18,20 @@
       <tbody class="hmrc-responsive-table__data">
         {% for row in rows %}
           {% set rowIndex = loop.index %}
-          <tr role="row">
-            <td role="cell" data-testrole="movements-list_row{{ rowIndex }}-updated">
+          <tr data-testrole="movements-list_row{{ rowIndex }}">
+            <td data-testrole="movements-list_row{{ rowIndex }}-updated">
               <span class="responsive-table__heading" aria-hidden="true">{{ rowHeadingUpdated }}</span>
               {{ row.updated }}
             </td>
-            <td role="cell" data-testrole="movements-list_row{{ rowIndex }}-ref">
+            <td data-testrole="movements-list_row{{ rowIndex }}-ref">
               <span class="responsive-table__heading" aria-hidden="true">{{ rowHeadingMrn }}</span>
               {{ row.referenceNumber }}
             </td>
-            <td role="cell" data-testrole="movements-list_row{{ rowIndex }}-status">
+            <td data-testrole="movements-list_row{{ rowIndex }}-status">
               <span class="responsive-table__heading" aria-hidden="true">{{ rowHeadingStatus }}</span>
               {{ messages(row.status) }}
             </td>
-            <td role="cell" data-testrole="movements-list_row{{ rowIndex }}-actions">
+            <td data-testrole="movements-list_row{{ rowIndex }}-actions">
               <span class="responsive-table__heading" aria-hidden="true">{{ rowHeadingAction }}</span>
 
               {% for action in row.actions %}

--- a/conf/views/macros/showMovementsByDate.njk
+++ b/conf/views/macros/showMovementsByDate.njk
@@ -37,8 +37,8 @@
               {% for action in row.actions %}
                 {% set actionIndex = loop.index %}
                 <a id="{{ messages(action.key) | replace(" ", "-")  }}-{{ row.referenceNumber }}" href="{{ action.href }}" class="action-link" data-testrole="movements-list_row{{ rowIndex }}-action{{ actionIndex }}">
-                  <span aria-hidden="true">{{ messages(action.key) }}</span>
-                  <span class="govuk-visually-hidden">{{ messages(action.key + ".hidden", row.referenceNumber) }}</span>
+                  {{ messages(action.key) }}
+                  <span class="govuk-visually-hidden">{{ messages("viewArrivalNotifications.table.action.hidden", row.referenceNumber) }}</span>
                 </a>
               {% endfor %}
             </td>

--- a/test/views/behaviours/MovementsTableViewBehaviours.scala
+++ b/test/views/behaviours/MovementsTableViewBehaviours.scala
@@ -49,34 +49,38 @@ abstract class MovementsTableViewBehaviours(override protected val viewUnderTest
       ls.eq(5).text() mustBe "11 August 2020"
     }
 
-    "generate a row for each movement" - {
-      val rows: Elements = doc.getElementsByAttributeValue("role", "row")
+    val rows: Elements = doc.select("tr[data-testrole^=movements-list_row]")
+
+    "generate a row for each movement" in {
       rows.size() mustEqual 7
+    }
+
+    "generate correct data in each row" - {
       rows.toList.zipWithIndex.forEach {
         x =>
           s"row ${x._2 + 1}" - {
 
             "display correct time" in {
-              val updated = x._1.selectFirst("[data-testrole*=updated]")
+              val updated = x._1.selectFirst("td[data-testrole*=-updated]")
               val time    = Json.toJson(viewMovements(x._2)).transform((JsPath \ "updated").json.pick[JsString]).get.value
               updated.ownText() mustBe time
               updated.text() mustBe s"$messageKeyPrefix.table.updated $time"
             }
 
             "display correct reference number" in {
-              val ref = x._1.selectFirst("[data-testrole*=ref]")
+              val ref = x._1.selectFirst("td[data-testrole*=-ref]")
               ref.ownText() mustBe viewMovements(x._2).referenceNumber
               ref.text() mustBe s"$messageKeyPrefix.table.$refType ${viewMovements(x._2).referenceNumber}"
             }
 
             "display correct status" in {
-              val status = x._1.selectFirst("[data-testrole*=status]")
+              val status = x._1.selectFirst("td[data-testrole*=-status]")
               status.ownText() mustBe viewMovements(x._2).status
               status.text() mustBe s"$messageKeyPrefix.table.status ${viewMovements(x._2).status}"
             }
 
             "display actions" - {
-              val actions = x._1.selectFirst("[data-testrole*=actions]")
+              val actions = x._1.selectFirst("td[data-testrole*=-actions]")
 
               "include hidden content" in {
                 actions.text() must include(s"$messageKeyPrefix.table.action")

--- a/test/views/behaviours/MovementsTableViewBehaviours.scala
+++ b/test/views/behaviours/MovementsTableViewBehaviours.scala
@@ -92,7 +92,7 @@ abstract class MovementsTableViewBehaviours(override protected val viewUnderTest
                   s"action ${y._2 + 1}" - {
 
                     "display correct text" in {
-                      y._1.text() mustBe s"${viewMovements(x._2).actions(y._2).key} ${s"${viewMovements(x._2).actions(y._2).key}.hidden"}"
+                      y._1.text() mustBe s"${viewMovements(x._2).actions(y._2).key} viewArrivalNotifications.table.action.hidden"
                     }
 
                     "have correct id" in {


### PR DESCRIPTION
- The “row” role is unnecessary for element “tr” (fix: removed `role="row"`)
- The “cell” role is unnecessary for element “td” (fix: removed `role="cell"`)
- Ensure that links with the same accessible name serve a similar purpose (fix: amended markup of action links in movements table while maintaining current voiceover behaviour)