### PR TITLE
Fixing flakey view specs.

### DIFF
--- a/conf/views/macros/showMovementsByDate.njk
+++ b/conf/views/macros/showMovementsByDate.njk
@@ -20,19 +20,19 @@
           {% set rowIndex = loop.index %}
           <tr data-testrole="movements-list_row{{ rowIndex }}">
             <td data-testrole="movements-list_row{{ rowIndex }}-updated">
-              <span class="responsive-table__heading" aria-hidden="true">{{ rowHeadingUpdated }}</span>
+              <span class="govuk-visually-hidden">{{ rowHeadingUpdated }}</span>
               {{ row.updated }}
             </td>
             <td data-testrole="movements-list_row{{ rowIndex }}-ref">
-              <span class="responsive-table__heading" aria-hidden="true">{{ rowHeadingMrn }}</span>
+              <span class="govuk-visually-hidden">{{ rowHeadingMrn }}</span>
               {{ row.referenceNumber }}
             </td>
             <td data-testrole="movements-list_row{{ rowIndex }}-status">
-              <span class="responsive-table__heading" aria-hidden="true">{{ rowHeadingStatus }}</span>
+              <span class="govuk-visually-hidden">{{ rowHeadingStatus }}</span>
               {{ messages(row.status) }}
             </td>
             <td data-testrole="movements-list_row{{ rowIndex }}-actions">
-              <span class="responsive-table__heading" aria-hidden="true">{{ rowHeadingAction }}</span>
+              <span class="govuk-visually-hidden">{{ rowHeadingAction }}</span>
 
               {% for action in row.actions %}
                 {% set actionIndex = loop.index %}

--- a/test/views/behaviours/MovementsTableViewBehaviours.scala
+++ b/test/views/behaviours/MovementsTableViewBehaviours.scala
@@ -18,7 +18,7 @@ package views.behaviours
 
 import base.FakeFrontendAppConfig
 import config.FrontendAppConfig
-import org.jsoup.nodes.Document
+import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import play.api.libs.json._
 import viewModels.ViewMovement
@@ -57,50 +57,62 @@ abstract class MovementsTableViewBehaviours(override protected val viewUnderTest
 
     "generate correct data in each row" - {
       rows.toList.zipWithIndex.forEach {
-        x =>
-          s"row ${x._2 + 1}" - {
+        case (row, rowIndex) =>
+          s"row ${rowIndex + 1}" - {
+
+            def elementWithVisibleText(element: Element, text: String): Unit =
+              element.ownText() mustBe text.trim
+
+            def elementWithHiddenText(element: Element, text: String): Unit = {
+              val hiddenText = element.getElementsByClass("govuk-visually-hidden").head
+              hiddenText.text() mustBe text
+            }
 
             "display correct time" in {
-              val updated = x._1.selectFirst("td[data-testrole*=-updated]")
-              val time    = Json.toJson(viewMovements(x._2)).transform((JsPath \ "updated").json.pick[JsString]).get.value
-              updated.ownText() mustBe time
-              updated.text() mustBe s"$messageKeyPrefix.table.updated $time"
+              val updated = row.selectFirst("td[data-testrole*=-updated]")
+              val time    = Json.toJson(viewMovements(rowIndex)).transform((JsPath \ "updated").json.pick[JsString]).get.value
+
+              behave like elementWithVisibleText(updated, time)
+              behave like elementWithHiddenText(updated, s"$messageKeyPrefix.table.updated")
             }
 
             "display correct reference number" in {
-              val ref = x._1.selectFirst("td[data-testrole*=-ref]")
-              ref.ownText() mustBe viewMovements(x._2).referenceNumber
-              ref.text() mustBe s"$messageKeyPrefix.table.$refType ${viewMovements(x._2).referenceNumber}"
+              val ref = row.selectFirst("td[data-testrole*=-ref]")
+
+              behave like elementWithVisibleText(ref, viewMovements(rowIndex).referenceNumber)
+              behave like elementWithHiddenText(ref, s"$messageKeyPrefix.table.$refType")
             }
 
             "display correct status" in {
-              val status = x._1.selectFirst("td[data-testrole*=-status]")
-              status.ownText() mustBe viewMovements(x._2).status
-              status.text() mustBe s"$messageKeyPrefix.table.status ${viewMovements(x._2).status}"
+              val status = row.selectFirst("td[data-testrole*=-status]")
+
+              behave like elementWithVisibleText(status, viewMovements(rowIndex).status)
+              behave like elementWithHiddenText(status, s"$messageKeyPrefix.table.status")
             }
 
             "display actions" - {
-              val actions = x._1.selectFirst("td[data-testrole*=-actions]")
+              val actions = row.selectFirst("td[data-testrole*=-actions]")
 
               "include hidden content" in {
-                actions.text() must include(s"$messageKeyPrefix.table.action")
+                behave like elementWithHiddenText(actions, s"$messageKeyPrefix.table.action")
               }
 
-              val actionLinks = actions.getElementsByTag("a")
-              actionLinks.zipWithIndex.forEach {
-                y =>
-                  s"action ${y._2 + 1}" - {
+              val links = actions.getElementsByClass("action-link")
+              links.zipWithIndex.forEach {
+                case (link, linkIndex) =>
+                  s"action ${linkIndex + 1}" - {
 
                     "display correct text" in {
-                      y._1.text() mustBe s"${viewMovements(x._2).actions(y._2).key} viewArrivalNotifications.table.action.hidden"
+                      behave like elementWithVisibleText(link, s"${viewMovements(rowIndex).actions(linkIndex).key}")
+                      behave like elementWithHiddenText(link, "viewArrivalNotifications.table.action.hidden")
                     }
 
                     "have correct id" in {
-                      y._1.attr("id") mustBe s"${viewMovements(x._2).actions(y._2).key}-${viewMovements(x._2).referenceNumber}"
+                      link.attr("id") mustBe s"${viewMovements(rowIndex).actions(linkIndex).key}-${viewMovements(rowIndex).referenceNumber}"
                     }
 
                     "have correct href" in {
-                      y._1.attr("href") mustBe viewMovements(x._2).actions(y._2).href
+                      link.attr("href") mustBe viewMovements(rowIndex).actions(linkIndex).href
                     }
                   }
               }


### PR DESCRIPTION
Calling `.ownText` on an element trims the result, so if the arbitrarily generated value has leading or trailing spaces the equality assertion will fail.

PR also includes refactoring `class="responsive-table__heading" aria-hidden="true"` to just be `class="govuk-visually-hidden"`, thus making the implementation of making content hidden consistent across the macro