### PR TITLE
Fixing flakey view specs.

### DIFF
--- a/test/views/behaviours/ViewBehaviours.scala
+++ b/test/views/behaviours/ViewBehaviours.scala
@@ -37,6 +37,7 @@ abstract class ViewBehaviours(override protected val viewUnderTest: String) exte
       assertPageHasLink(doc, id, expectedText, expectedHref)
     }
 
+  // scalastyle:off method.length
   def pageWithPagination(href: String): Unit =
     "Pagination" - {
 
@@ -102,6 +103,7 @@ abstract class ViewBehaviours(override protected val viewUnderTest: String) exte
         assertRenderedById(doc, "pagination-item-12")
       }
     }
+  // scalastyle:on method.length
 
   def pageWithMovementSearch(doc: Document, id: String, expectedText: String): Unit =
     "displays search box" - {


### PR DESCRIPTION
Calling `.ownText()` on an element trims the result, so if the arbitrarily generated value has leading or trailing spaces the equality assertion will fail.