### PR TITLE
CTCP-2968 | Small device search box overflowing fix

### DIFF
--- a/app/assets/stylesheets/components/_search.scss
+++ b/app/assets/stylesheets/components/_search.scss
@@ -8,7 +8,7 @@
   }
 }
 
-@media all and (max-width: 600px)
+@media all and (min-width: 0px) and (max-width: 600px)
 {
   .search-input-custom {
     text-size-adjust: 100%;

--- a/app/assets/stylesheets/components/_search.scss
+++ b/app/assets/stylesheets/components/_search.scss
@@ -7,3 +7,22 @@
     vertical-align: bottom;
   }
 }
+
+@media all and (max-width: 600px)
+{
+  .search-input-custom {
+    text-size-adjust: 100%;
+    margin-bottom: 30px;
+    display: inline-block;
+  }
+}
+
+@media all and (min-width: 601px) and (max-width: 1024px)
+{
+  .search-input-custom {
+    text-size-adjust: 100%;
+    margin-bottom: 30px;
+    width: 50% !important;
+    display: inline-block;
+  }
+}

--- a/app/assets/stylesheets/components/_search.scss
+++ b/app/assets/stylesheets/components/_search.scss
@@ -17,7 +17,7 @@
   }
 }
 
-@media all and (min-width: 601px) and (max-width: 1024px)
+@media all and (min-width: 601px)
 {
   .search-input-custom {
     text-size-adjust: 100%;

--- a/app/assets/stylesheets/components/_search.scss
+++ b/app/assets/stylesheets/components/_search.scss
@@ -15,6 +15,17 @@
     margin-bottom: 30px;
     display: inline-block;
   }
+
+  .govuk-form-group {
+    margin-bottom: 20px;
+    width: 100%;
+  }
+
+  .govuk-form-group--error {
+    padding-left: 15px;
+    border-left: 5px solid #d4351c;
+    width: auto;
+  }
 }
 
 @media all and (min-width: 601px)

--- a/app/views/utils/ViewUtils.scala
+++ b/app/views/utils/ViewUtils.scala
@@ -38,7 +38,6 @@ object ViewUtils {
       label = Label(
         content = messages(label).toText
       ),
-      formGroupClasses = "govuk-!-width-one-half",
       errorMessage = field.error.map {
         e =>
           ErrorMessage.errorMessageWithDefaultStringsTranslated(content = Text(messages(e.message, e.args: _*)))

--- a/app/views/utils/ViewUtils.scala
+++ b/app/views/utils/ViewUtils.scala
@@ -38,6 +38,7 @@ object ViewUtils {
       label = Label(
         content = messages(label).toText
       ),
+      formGroupClasses = "search-input-custom",
       errorMessage = field.error.map {
         e =>
           ErrorMessage.errorMessageWithDefaultStringsTranslated(content = Text(messages(e.message, e.args: _*)))


### PR DESCRIPTION
The search box (arrivals.dep,drafts search) overflows when used on small devices due to a class that forces widths  one half. 