### PR TITLE
CTCP-5693

### DIFF
--- a/app/controllers/departureP5/CancellationNotificationErrorsP5Controller.scala
+++ b/app/controllers/departureP5/CancellationNotificationErrorsP5Controller.scala
@@ -49,7 +49,7 @@ class CancellationNotificationErrorsP5Controller @Inject() (
         if (functionalErrors.isEmpty) {
           referenceDataService.getCustomsOffice(customsOfficeReference).map {
             customsOffice =>
-              Ok(view(viewModelProvider.apply(request.referenceNumbers.localReferenceNumber.value, customsOffice)))
+              Ok(view(viewModelProvider.apply(request.referenceNumbers.localReferenceNumber, customsOffice)))
           }
         } else {
           Future.successful(Redirect(controllers.routes.ErrorController.technicalDifficulties()))

--- a/app/controllers/departureP5/DepartureCancelledP5Controller.scala
+++ b/app/controllers/departureP5/DepartureCancelledP5Controller.scala
@@ -19,7 +19,6 @@ package controllers.departureP5
 import config.FrontendAppConfig
 import controllers.actions._
 import generated.CC009CType
-import models.LocalReferenceNumber
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc._
 import services.ReferenceDataService
@@ -50,13 +49,13 @@ class DepartureCancelledP5Controller @Inject() (
 
   private def buildView(
     ie009: CC009CType,
-    lrn: LocalReferenceNumber
+    lrn: String
   )(implicit request: Request[_]): Future[Result] = {
     val customsOfficeReferenceNumber = ie009.CustomsOfficeOfDeparture.referenceNumber
 
     referenceDataService.getCustomsOffice(customsOfficeReferenceNumber).flatMap {
       customsOffice =>
-        viewModelProvider.apply(ie009, lrn.value, customsOffice).map {
+        viewModelProvider.apply(ie009, lrn, customsOffice).map {
           viewModel => Ok(view(viewModel))
         }
     }

--- a/app/controllers/departureP5/DepartureDeclarationErrorsP5Controller.scala
+++ b/app/controllers/departureP5/DepartureDeclarationErrorsP5Controller.scala
@@ -45,7 +45,7 @@ class DepartureDeclarationErrorsP5Controller @Inject() (
         if (request.messageData.FunctionalError.isEmpty) {
           Ok(
             view(
-              viewModelProvider.apply(request.referenceNumbers.localReferenceNumber.value, isAmendmentJourney),
+              viewModelProvider.apply(request.referenceNumbers.localReferenceNumber, isAmendmentJourney),
               isAmendmentJourney,
               request.referenceNumbers.movementReferenceNumber
             )

--- a/app/controllers/departureP5/DepartureNotCancelledP5Controller.scala
+++ b/app/controllers/departureP5/DepartureNotCancelledP5Controller.scala
@@ -19,7 +19,6 @@ package controllers.departureP5
 import config.FrontendAppConfig
 import controllers.actions._
 import generated.CC009CType
-import models.LocalReferenceNumber
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc._
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -49,9 +48,9 @@ class DepartureNotCancelledP5Controller @Inject() (
   private def buildView(
     ie009: CC009CType,
     departureId: String,
-    lrn: LocalReferenceNumber
+    lrn: String
   )(implicit request: Request[_]): Future[Result] =
-    viewModelProvider.apply(ie009, departureId, lrn.value).map {
+    viewModelProvider.apply(ie009, departureId, lrn).map {
       viewModel => Ok(view(viewModel))
     }
 }

--- a/app/controllers/departureP5/GoodsNotReleasedP5Controller.scala
+++ b/app/controllers/departureP5/GoodsNotReleasedP5Controller.scala
@@ -43,7 +43,7 @@ class GoodsNotReleasedP5Controller @Inject() (
     (Action andThen actions.checkP5Switch() andThen messageRetrievalAction[CC051CType](departureId, messageId)) {
       implicit request =>
         Ok(
-          view(viewModelProvider.apply(request.messageData, request.referenceNumbers.localReferenceNumber.value))
+          view(viewModelProvider.apply(request.messageData, request.referenceNumbers.localReferenceNumber))
         )
     }
 }

--- a/app/controllers/departureP5/RejectionMessageP5Controller.scala
+++ b/app/controllers/departureP5/RejectionMessageP5Controller.scala
@@ -50,9 +50,9 @@ class RejectionMessageP5Controller @Inject() (
         val functionalErrors = request.messageData.FunctionalError
 
         val isDataValid: Future[Boolean] = if (isAmendmentJourney.getOrElse(false)) {
-          cacheConnector.doesDeclarationExist(lrn.value)
+          cacheConnector.doesDeclarationExist(lrn)
         } else {
-          cacheConnector.isDeclarationAmendable(lrn.value, functionalErrors.map(_.errorPointer))
+          cacheConnector.isDeclarationAmendable(lrn, functionalErrors.map(_.errorPointer))
         }
 
         isDataValid.flatMap {
@@ -68,7 +68,7 @@ class RejectionMessageP5Controller @Inject() (
             )
 
             val rejectionMessageP5ViewModel =
-              viewModelProvider.apply(request.messageData.pagedFunctionalErrors(currentPage), lrn.value, isAmendmentJourney.getOrElse(false))
+              viewModelProvider.apply(request.messageData.pagedFunctionalErrors(currentPage), lrn, isAmendmentJourney.getOrElse(false))
 
             rejectionMessageP5ViewModel.map(
               viewModel =>
@@ -96,25 +96,25 @@ class RejectionMessageP5Controller @Inject() (
 
         if (isAmendmentJourney) {
           for {
-            doesCacheExistForLrn  <- cacheConnector.doesDeclarationExist(lrn.value)
-            handleAmendmentErrors <- cacheConnector.handleAmendmentErrors(lrn.value, xPaths)
+            doesCacheExistForLrn  <- cacheConnector.doesDeclarationExist(lrn)
+            handleAmendmentErrors <- cacheConnector.handleAmendmentErrors(lrn, xPaths)
           } yield (doesCacheExistForLrn, handleAmendmentErrors) match {
             case (true, true) =>
-              Redirect(config.departureAmendmentUrl(lrn.value, departureId))
+              Redirect(config.departureAmendmentUrl(lrn, departureId))
             case _ =>
               Redirect(controllers.routes.ErrorController.technicalDifficulties())
           }
         } else {
           for {
-            isDeclarationAmendable <- cacheConnector.isDeclarationAmendable(lrn.value, xPaths)
-            handleErrors           <- cacheConnector.handleErrors(lrn.value, xPaths)
+            isDeclarationAmendable <- cacheConnector.isDeclarationAmendable(lrn, xPaths)
+            handleErrors           <- cacheConnector.handleErrors(lrn, xPaths)
           } yield (isDeclarationAmendable, handleErrors) match {
             case (true, true) =>
               if (xPaths.nonEmpty) {
                 if (request.referenceNumbers.movementReferenceNumber.isDefined) {
-                  Redirect(config.departureNewLocalReferenceNumberUrl(lrn.value))
+                  Redirect(config.departureNewLocalReferenceNumberUrl(lrn))
                 } else {
-                  Redirect(config.departureFrontendTaskListUrl(lrn.value))
+                  Redirect(config.departureFrontendTaskListUrl(lrn))
                 }
               } else {
                 Redirect(controllers.routes.ErrorController.technicalDifficulties())

--- a/app/controllers/departureP5/ReviewCancellationErrorsP5Controller.scala
+++ b/app/controllers/departureP5/ReviewCancellationErrorsP5Controller.scala
@@ -55,7 +55,7 @@ class ReviewCancellationErrorsP5Controller @Inject() (
         )
 
         val rejectionMessageP5ViewModel =
-          viewModelProvider.apply(request.messageData.pagedFunctionalErrors(currentPage), request.referenceNumbers.localReferenceNumber.value)
+          viewModelProvider.apply(request.messageData.pagedFunctionalErrors(currentPage), request.referenceNumbers.localReferenceNumber)
 
         rejectionMessageP5ViewModel.map(
           viewModel => Ok(view(viewModel, departureId, paginationViewModel))

--- a/app/controllers/departureP5/ReviewDepartureErrorsP5Controller.scala
+++ b/app/controllers/departureP5/ReviewDepartureErrorsP5Controller.scala
@@ -57,7 +57,7 @@ class ReviewDepartureErrorsP5Controller @Inject() (
         val rejectionMessageP5ViewModel =
           viewModelProvider.apply(
             request.messageData.pagedFunctionalErrors(currentPage),
-            request.referenceNumbers.localReferenceNumber.value,
+            request.referenceNumbers.localReferenceNumber,
             isAmendmentJourney.getOrElse(false)
           )
         rejectionMessageP5ViewModel.map(

--- a/app/controllers/departureP5/drafts/DeleteDraftDepartureYesNoController.scala
+++ b/app/controllers/departureP5/drafts/DeleteDraftDepartureYesNoController.scala
@@ -46,11 +46,11 @@ class DeleteDraftDepartureYesNoController @Inject() (
   def onPageLoad(lrn: LocalReferenceNumber, pageNumber: Int, numberOfRows: Int, searchLrn: Option[String]): Action[AnyContent] =
     (Action andThen actions.checkP5Switch() andThen lockAction(lrn.value)) {
       implicit request =>
-        Ok(view(form, lrn.value, pageNumber, numberOfRows, searchLrn))
+        Ok(view(form, lrn, pageNumber, numberOfRows, searchLrn))
     }
 
-  def onSubmit(lrn: String, pageNumber: Int, numberOfRows: Int, searchLrn: Option[String]): Action[AnyContent] =
-    (Action andThen actions.checkP5Switch() andThen lockAction(lrn)).async {
+  def onSubmit(lrn: LocalReferenceNumber, pageNumber: Int, numberOfRows: Int, searchLrn: Option[String]): Action[AnyContent] =
+    (Action andThen actions.checkP5Switch() andThen lockAction(lrn.value)).async {
       implicit request =>
         form
           .bindFromRequest()
@@ -58,7 +58,7 @@ class DeleteDraftDepartureYesNoController @Inject() (
             formWithErrors => Future.successful(BadRequest(view(formWithErrors, lrn, pageNumber, numberOfRows, searchLrn))),
             {
               case true =>
-                draftDepartureService.deleteDraftDeparture(lrn) map {
+                draftDepartureService.deleteDraftDeparture(lrn.value) map {
                   case response if response.status == StatusOK =>
                     val redirectPageNumber: Int = pageNumber match {
                       case 1                               => 1

--- a/app/models/departureP5/DepartureMovement.scala
+++ b/app/models/departureP5/DepartureMovement.scala
@@ -16,7 +16,7 @@
 
 package models.departureP5
 
-import models.{LocalReferenceNumber, Movement}
+import models.Movement
 import play.api.libs.json.{__, Reads}
 
 import java.time.LocalDateTime
@@ -24,7 +24,7 @@ import java.time.LocalDateTime
 case class DepartureMovement(
   departureId: String,
   movementReferenceNumber: Option[String],
-  localReferenceNumber: LocalReferenceNumber,
+  localReferenceNumber: String,
   updated: LocalDateTime
 ) extends Movement
 
@@ -35,7 +35,7 @@ object DepartureMovement {
     (
       (__ \ "id").read[String] and
         (__ \ "movementReferenceNumber").readNullable[String] and
-        (__ \ "localReferenceNumber").read[LocalReferenceNumber] and
+        (__ \ "localReferenceNumber").read[String] and
         (__ \ "updated").read[LocalDateTime]
     )(DepartureMovement.apply _)
   }

--- a/app/models/departureP5/DepartureMovementAndMessage.scala
+++ b/app/models/departureP5/DepartureMovementAndMessage.scala
@@ -16,20 +16,18 @@
 
 package models.departureP5
 
-import models.LocalReferenceNumber
-
 import java.time.LocalDateTime
 
 sealed trait MovementAndMessage {
   val departureId: String
-  val localReferenceNumber: LocalReferenceNumber
+  val localReferenceNumber: String
   val message: LatestDepartureMessage
   val updated: LocalDateTime
 }
 
 case class RejectedMovementAndMessage(
   departureId: String,
-  localReferenceNumber: LocalReferenceNumber,
+  localReferenceNumber: String,
   updated: LocalDateTime,
   message: LatestDepartureMessage,
   rejectionType: String,
@@ -40,14 +38,14 @@ case class RejectedMovementAndMessage(
 
 case class OtherMovementAndMessage(
   departureId: String,
-  localReferenceNumber: LocalReferenceNumber,
+  localReferenceNumber: String,
   updated: LocalDateTime,
   message: LatestDepartureMessage
 ) extends MovementAndMessage
 
 case class DepartureMovementAndMessage(
   departureId: String,
-  localReferenceNumber: LocalReferenceNumber,
+  localReferenceNumber: String,
   updated: LocalDateTime,
   message: LatestDepartureMessage,
   isPrelodged: Boolean

--- a/app/models/departureP5/DepartureReferenceNumbers.scala
+++ b/app/models/departureP5/DepartureReferenceNumbers.scala
@@ -16,17 +16,16 @@
 
 package models.departureP5
 
-import models.LocalReferenceNumber
 import play.api.libs.functional.syntax.toFunctionalBuilderOps
 import play.api.libs.json._
 
-case class DepartureReferenceNumbers(localReferenceNumber: LocalReferenceNumber, movementReferenceNumber: Option[String])
+case class DepartureReferenceNumbers(localReferenceNumber: String, movementReferenceNumber: Option[String])
 
 object DepartureReferenceNumbers {
 
   implicit val reads: Reads[DepartureReferenceNumbers] =
     (
-      (__ \ "localReferenceNumber").read[LocalReferenceNumber] and
+      (__ \ "localReferenceNumber").read[String] and
         (__ \ "movementReferenceNumber").readNullable[String]
     )(DepartureReferenceNumbers.apply _)
 

--- a/app/services/DepartureP5MessageService.scala
+++ b/app/services/DepartureP5MessageService.scala
@@ -55,7 +55,7 @@ class DepartureP5MessageService @Inject() (
           message =>
             message.latestMessage.messageType match {
               case RejectedByOfficeOfDeparture =>
-                isErrorAmendable(movement.departureId, message.latestMessage.messageId, movement.localReferenceNumber.value).map {
+                isErrorAmendable(movement.departureId, message.latestMessage.messageId, movement.localReferenceNumber).map {
                   case (rejectionType, isDeclarationAmendable, xPaths, doesCacheExistForLrn) =>
                     RejectedMovementAndMessage(
                       movement.departureId,

--- a/app/viewModels/P5/departure/DepartureStatusP5ViewModel.scala
+++ b/app/viewModels/P5/departure/DepartureStatusP5ViewModel.scala
@@ -16,9 +16,8 @@
 
 package viewModels.P5.departure
 
-import config.FrontendAppConfig
-import models.LocalReferenceNumber
 import config.Constants.BusinessRejectionType._
+import config.FrontendAppConfig
 import models.departureP5.DepartureMessageType._
 import models.departureP5._
 import viewModels.ViewMovementAction
@@ -52,7 +51,7 @@ object DepartureStatusP5ViewModel {
       rejectedByOfficeOfDeparture(departureId, messageId, rejectionType, isDeclarationAmendable, xPaths, doesCacheExistForLrn)
     ).reduce(_ orElse _)
 
-  private def preLodgeStatus(departureId: String, messageId: String, localReferenceNumber: LocalReferenceNumber, isPrelodge: Boolean)(implicit
+  private def preLodgeStatus(departureId: String, messageId: String, localReferenceNumber: String, isPrelodge: Boolean)(implicit
     frontendAppConfig: FrontendAppConfig
   ): PartialFunction[DepartureMessage, DepartureStatusP5ViewModel] =
     Seq(
@@ -61,7 +60,7 @@ object DepartureStatusP5ViewModel {
       declarationSent(departureId, localReferenceNumber, isPrelodge)
     ).reduce(_ orElse _)
 
-  private def currentStatus(departureId: String, messageId: String, localReferenceNumber: LocalReferenceNumber)(implicit
+  private def currentStatus(departureId: String, messageId: String, localReferenceNumber: String)(implicit
     frontendAppConfig: FrontendAppConfig
   ): PartialFunction[DepartureMessage, DepartureStatusP5ViewModel] =
     Seq(
@@ -83,7 +82,7 @@ object DepartureStatusP5ViewModel {
       movementEnded
     ).reduce(_ orElse _)
 
-  private def declarationAmendmentAccepted(departureId: String, lrn: LocalReferenceNumber, prelodged: Boolean)(implicit
+  private def declarationAmendmentAccepted(departureId: String, lrn: String, prelodged: Boolean)(implicit
     frontendAppConfig: FrontendAppConfig
   ): PartialFunction[DepartureMessage, DepartureStatusP5ViewModel] = {
     case message if message.messageType == DeclarationAmendmentAccepted =>
@@ -106,7 +105,7 @@ object DepartureStatusP5ViewModel {
         "movement.status.P5.declarationAmendmentAccepted",
         actions = Seq(
           ViewMovementAction(
-            s"${frontendAppConfig.departureAmendmentUrl(lrn.value, departureId)}",
+            s"${frontendAppConfig.departureAmendmentUrl(lrn, departureId)}",
             "movement.status.P5.action.declarationAmendmentAccepted.amendDeclaration"
           )
         ) ++ prelodgeAction
@@ -115,14 +114,14 @@ object DepartureStatusP5ViewModel {
 
   private def allocatedMRN(
     departureId: String,
-    lrn: LocalReferenceNumber
+    lrn: String
   )(implicit frontendAppConfig: FrontendAppConfig): PartialFunction[DepartureMessage, DepartureStatusP5ViewModel] = {
     case message if message.messageType == AllocatedMRN =>
       DepartureStatusP5ViewModel(
         "movement.status.P5.allocatedMRN",
         actions = Seq(
           ViewMovementAction(
-            s"${frontendAppConfig.departureAmendmentUrl(lrn.value, departureId)}",
+            s"${frontendAppConfig.departureAmendmentUrl(lrn, departureId)}",
             "movement.status.P5.action.declarationAmendmentAccepted.amendDeclaration"
           ),
           ViewMovementAction(
@@ -240,14 +239,14 @@ object DepartureStatusP5ViewModel {
 
   private def guaranteeRejected(
     departureId: String,
-    lrn: LocalReferenceNumber
+    lrn: String
   )(implicit frontendAppConfig: FrontendAppConfig): PartialFunction[DepartureMessage, DepartureStatusP5ViewModel] = {
     case message if message.messageType == GuaranteeRejected =>
       DepartureStatusP5ViewModel(
         "movement.status.P5.guaranteeRejected",
         actions = Seq(
           ViewMovementAction(
-            controllers.departureP5.routes.GuaranteeRejectedP5Controller.onPageLoad(departureId, message.messageId, lrn).url,
+            controllers.departureP5.routes.GuaranteeRejectedP5Controller.onPageLoad(departureId, message.messageId).url,
             "movement.status.P5.action.guaranteeRejected.viewErrors"
           ),
           ViewMovementAction(
@@ -325,7 +324,7 @@ object DepartureStatusP5ViewModel {
   private def goodsUnderControl(
     departureId: String,
     messageId: String,
-    lrn: LocalReferenceNumber,
+    lrn: String,
     prelodged: Boolean
   )(implicit frontendAppConfig: FrontendAppConfig): PartialFunction[DepartureMessage, DepartureStatusP5ViewModel] = {
     case message if message.messageType == GoodsUnderControl =>
@@ -367,7 +366,7 @@ object DepartureStatusP5ViewModel {
 
   private def declarationSent(
     departureId: String,
-    lrn: LocalReferenceNumber,
+    lrn: String,
     prelodged: Boolean
   )(implicit frontendAppConfig: FrontendAppConfig): PartialFunction[DepartureMessage, DepartureStatusP5ViewModel] = {
     case message if message.messageType == DeclarationSent =>
@@ -377,7 +376,7 @@ object DepartureStatusP5ViewModel {
           case true =>
             Seq(
               ViewMovementAction(
-                s"${frontendAppConfig.departureAmendmentUrl(lrn.value, departureId)}",
+                s"${frontendAppConfig.departureAmendmentUrl(lrn, departureId)}",
                 "movement.status.P5.action.declarationAmendmentAccepted.amendDeclaration"
               ),
               ViewMovementAction(

--- a/app/viewModels/P5/departure/GuaranteeRejectedP5ViewModel.scala
+++ b/app/viewModels/P5/departure/GuaranteeRejectedP5ViewModel.scala
@@ -17,7 +17,6 @@
 package viewModels.P5.departure
 
 import generated.GuaranteeReferenceType08
-import models.LocalReferenceNumber
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.table.Table
 import utils.GuaranteeRejectedP5Helper
@@ -27,7 +26,7 @@ import javax.xml.datatype.XMLGregorianCalendar
 
 case class GuaranteeRejectedP5ViewModel(
   guaranteeReferences: Seq[GuaranteeReferenceType08],
-  lrn: LocalReferenceNumber,
+  lrn: String,
   isAmendable: Boolean,
   mrn: String,
   acceptanceDate: XMLGregorianCalendar

--- a/app/viewModels/P5/departure/ViewDepartureP5.scala
+++ b/app/viewModels/P5/departure/ViewDepartureP5.scala
@@ -41,7 +41,7 @@ object ViewDepartureP5 {
     ViewDepartureP5(
       updatedDate = systemTime.toLocalDate,
       updatedTime = systemTime.toLocalTime,
-      referenceNumber = movementAndMessage.localReferenceNumber.value,
+      referenceNumber = movementAndMessage.localReferenceNumber,
       status = departureStatus.status,
       actions = departureStatus.actions
     )

--- a/app/views/departureP5/GuaranteeRejectedP5View.scala.html
+++ b/app/views/departureP5/GuaranteeRejectedP5View.scala.html
@@ -40,7 +40,7 @@
 
     @heading(
         heading = messages("guarantee.rejected.message.heading"),
-        caption = Some(messages("departure.messages.caption", viewModel.lrn.value))
+        caption = Some(messages("departure.messages.caption", viewModel.lrn))
     )
 
     <p class="govuk-body" id="paragraph1">@viewModel.paragraph1</p>
@@ -57,7 +57,7 @@
     </p>
 
     @if(viewModel.isAmendable) {
-        @formHelper(action = routes.GuaranteeRejectedP5Controller.onAmend(departureId, messageId, viewModel.lrn), Symbol("autoComplete") -> "off") {
+        @formHelper(action = routes.GuaranteeRejectedP5Controller.onAmend(departureId, messageId), Symbol("autoComplete") -> "off") {
             @button(
                 attributes = Map("id" -> "submit"),
                 messageKey = messages("site.amendErrors")

--- a/app/views/departureP5/RecoveryNotificationView.scala.html
+++ b/app/views/departureP5/RecoveryNotificationView.scala.html
@@ -18,14 +18,14 @@
 @import viewModels.P5.departure.RecoveryNotificationViewModel
 
 @this(
-mainTemplate: MainTemplate,
-heading: Heading,
-answerSections: AnswerSections,
-button: Button,
-formHelper: FormWithCSRF
+    mainTemplate: MainTemplate,
+    heading: Heading,
+    answerSections: AnswerSections,
+    button: Button,
+    formHelper: FormWithCSRF
 )
 
-@(recoveryNotificationViewModel: RecoveryNotificationViewModel, lrn: LocalReferenceNumber)(implicit request: Request[_], messages: Messages)
+@(recoveryNotificationViewModel: RecoveryNotificationViewModel, lrn: String)(implicit request: Request[_], messages: Messages)
 
     @mainTemplate(
         title = recoveryNotificationViewModel.title,
@@ -34,7 +34,7 @@ formHelper: FormWithCSRF
 
     @heading(
         heading = recoveryNotificationViewModel.heading,
-        caption = Some(messages("departure.ie035.message.subheading", lrn.toString))
+        caption = Some(messages("departure.ie035.message.subheading", lrn))
     )
 
     <p class="govuk-body" id="paragraph1">@recoveryNotificationViewModel.paragraph1</p>

--- a/app/views/departureP5/drafts/DeleteDraftDepartureYesNoView.scala.html
+++ b/app/views/departureP5/drafts/DeleteDraftDepartureYesNoView.scala.html
@@ -28,11 +28,11 @@
     insetText : InsetText,
 )
 
-@(form: Form[Boolean], lrn: String, pageNumber: Int, numberOfRows: Int, searchLrn: Option[String])(implicit request: Request[_], messages: Messages)
+@(form: Form[Boolean], lrn: LocalReferenceNumber, pageNumber: Int, numberOfRows: Int, searchLrn: Option[String])(implicit request: Request[_], messages: Messages)
 
 @html = {
-<p class="govuk-body">@messages("departure.drafts.deleteDraftDepartureYesNo.paragraph")</p>
-@insetText(messages("departure.drafts.dashboard.table.action.delete.hidden", lrn))
+    <p class="govuk-body">@messages("departure.drafts.deleteDraftDepartureYesNo.paragraph")</p>
+    @insetText(messages("departure.drafts.dashboard.table.action.delete.hidden", lrn.value))
 }
 
 @mainTemplate(
@@ -49,8 +49,9 @@
             yesNoType = YesNoWithAdditionalHtml(
                 heading = messages("departure.drafts.deleteDraftDepartureYesNo.heading"),
                 additionalHtml = html
+            )
+        )
 
-        ))
         @button(attributes = Map("id" -> "submit"), messageKey = messages("departure.drafts.deleteDraftDepartureYesNo.button"))
     }
 }

--- a/conf/departures.drafts.routes
+++ b/conf/departures.drafts.routes
@@ -2,6 +2,6 @@ GET        /draft-declarations                                  controllers.depa
 POST       /draft-declarations                                  controllers.departureP5.drafts.DashboardController.onSubmit(sortParams: Option[String])
 
 GET        /draft-declarations/:lrn/delete                      controllers.departureP5.drafts.DeleteDraftDepartureYesNoController.onPageLoad(lrn: LocalReferenceNumber, page: Int, numberOfRows: Int, searchLrn: Option[String])
-POST       /draft-declarations/:lrn/delete                      controllers.departureP5.drafts.DeleteDraftDepartureYesNoController.onSubmit(lrn: String, page: Int, numberOfRows: Int, searchLrn: Option[String])
+POST       /draft-declarations/:lrn/delete                      controllers.departureP5.drafts.DeleteDraftDepartureYesNoController.onSubmit(lrn: LocalReferenceNumber, page: Int, numberOfRows: Int, searchLrn: Option[String])
 
 GET        /draft-declarations/cannot-delete                    controllers.departureP5.drafts.DraftLockedController.onPageLoad()

--- a/conf/departuresP5.routes
+++ b/conf/departuresP5.routes
@@ -37,5 +37,5 @@ GET        /:departureId/transit-accompanying-document/:messageId               
 
 GET        /:departureId/goods-not-released/:messageId                               controllers.departureP5.GoodsNotReleasedP5Controller.goodsNotReleased(departureId: String, messageId: String)
 
-GET        /:departureId/:messageId/amend-guarantee-errors/:lrn                      controllers.departureP5.GuaranteeRejectedP5Controller.onPageLoad(departureId: String, messageId: String, lrn: LocalReferenceNumber)
-POST       /:departureId/:messageId/amend-guarantee-errors/:lrn                      controllers.departureP5.GuaranteeRejectedP5Controller.onAmend(departureId: String, messageId: String, lrn: LocalReferenceNumber)
+GET        /:departureId/:messageId/amend-guarantee-errors                           controllers.departureP5.GuaranteeRejectedP5Controller.onPageLoad(departureId: String, messageId: String)
+POST       /:departureId/:messageId/amend-guarantee-errors                           controllers.departureP5.GuaranteeRejectedP5Controller.onAmend(departureId: String, messageId: String)

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -45,7 +45,7 @@ trait SpecBase extends AnyFreeSpec with Matchers with OptionValues with TryValue
 
   val fakeCustomsOffice: CustomsOffice = CustomsOffice("1234", "Customs Office", Some("01234567"))
 
-  val departureReferenceNumbers = DepartureReferenceNumbers(lrn, None)
+  val departureReferenceNumbers = DepartureReferenceNumbers(lrn.value, None)
 
   def injector: Injector                   = app.injector
   def fakeRequest: FakeRequest[AnyContent] = FakeRequest("", "")

--- a/test/connectors/DepartureMovementP5ConnectorSpec.scala
+++ b/test/connectors/DepartureMovementP5ConnectorSpec.scala
@@ -20,8 +20,8 @@ import base.SpecBase
 import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, get, okJson, urlEqualTo}
 import generators.Generators
 import helper.WireMockServerHandler
+import models.Availability
 import models.departureP5._
-import models.{Availability, LocalReferenceNumber}
 import org.scalacheck.Gen
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -155,13 +155,13 @@ class DepartureMovementP5ConnectorSpec extends SpecBase with WireMockServerHandl
             DepartureMovement(
               "63651574c3447b12",
               Some("27WF9X1FQ9RCKN0TM3"),
-              LocalReferenceNumber("AB123"),
+              "AB123",
               LocalDateTime.parse("2022-11-04T13:36:52.332Z", DateTimeFormatter.ISO_DATE_TIME)
             ),
             DepartureMovement(
               "6365135ba5e821ee",
               Some("27WF9X1FQ9RCKN0TM3"),
-              LocalReferenceNumber("CD123"),
+              "CD123",
               LocalDateTime.parse("2022-11-04T13:27:55.522Z", DateTimeFormatter.ISO_DATE_TIME)
             )
           ),
@@ -238,7 +238,7 @@ class DepartureMovementP5ConnectorSpec extends SpecBase with WireMockServerHandl
               DepartureMovement(
                 "63651574c3447b12",
                 None,
-                LocalReferenceNumber("LRN12345"),
+                "LRN12345",
                 LocalDateTime.parse("2022-11-04T13:36:52.332Z", DateTimeFormatter.ISO_DATE_TIME)
               )
             ),
@@ -261,7 +261,7 @@ class DepartureMovementP5ConnectorSpec extends SpecBase with WireMockServerHandl
               DepartureMovement(
                 "63651574c3447b12",
                 None,
-                LocalReferenceNumber("LRN12345"),
+                "LRN12345",
                 LocalDateTime.parse("2022-11-04T13:36:52.332Z", DateTimeFormatter.ISO_DATE_TIME)
               )
             ),
@@ -376,7 +376,7 @@ class DepartureMovementP5ConnectorSpec extends SpecBase with WireMockServerHandl
             .willReturn(okJson(responseJson.toString()))
         )
 
-        val expectedResult = DepartureReferenceNumbers(LocalReferenceNumber("DEF456"), Some("ABC123"))
+        val expectedResult = DepartureReferenceNumbers("DEF456", Some("ABC123"))
 
         connector.getDepartureReferenceNumbers(departureIdP5).futureValue mustBe expectedResult
       }
@@ -401,7 +401,7 @@ class DepartureMovementP5ConnectorSpec extends SpecBase with WireMockServerHandl
             .willReturn(okJson(responseJson.toString()))
         )
 
-        val expectedResult = DepartureReferenceNumbers(LocalReferenceNumber("DEF456"), None)
+        val expectedResult = DepartureReferenceNumbers("DEF456", None)
 
         connector.getDepartureReferenceNumbers(departureIdP5).futureValue mustBe expectedResult
       }

--- a/test/controllers/departure/ViewAllDeparturesP5ControllerSpec.scala
+++ b/test/controllers/departure/ViewAllDeparturesP5ControllerSpec.scala
@@ -21,7 +21,6 @@ import cats.data.NonEmptyList
 import connectors.DepartureMovementP5Connector
 import forms.DeparturesSearchFormProvider
 import generators.Generators
-import models.LocalReferenceNumber
 import models.departureP5.DepartureMessageType.DepartureNotification
 import models.departureP5._
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
@@ -68,7 +67,7 @@ class ViewAllDeparturesP5ControllerSpec extends SpecBase with ScalaCheckProperty
   val departureMovement: DepartureMovement = DepartureMovement(
     "63651574c3447b12",
     None,
-    LocalReferenceNumber("AB123"),
+    "AB123",
     dateTime
   )
 
@@ -110,7 +109,7 @@ class ViewAllDeparturesP5ControllerSpec extends SpecBase with ScalaCheckProperty
               Seq(
                 OtherMovementAndMessage(
                   departureIdP5,
-                  lrn,
+                  lrn.value,
                   dateTime,
                   LatestDepartureMessage(
                     DepartureMessage(
@@ -160,7 +159,7 @@ class ViewAllDeparturesP5ControllerSpec extends SpecBase with ScalaCheckProperty
               Seq(
                 OtherMovementAndMessage(
                   departureIdP5,
-                  lrn,
+                  lrn.value,
                   dateTime,
                   LatestDepartureMessage(
                     DepartureMessage(

--- a/test/controllers/departureP5/DepartureDeclarationErrorsP5ControllerSpec.scala
+++ b/test/controllers/departureP5/DepartureDeclarationErrorsP5ControllerSpec.scala
@@ -63,7 +63,7 @@ class DepartureDeclarationErrorsP5ControllerSpec extends SpecBase with AppWithDe
           when(mockDepartureP5MessageService.getMessage[CC056CType](any(), any())(any(), any(), any()))
             .thenReturn(Future.successful(message))
           when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-            .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+            .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
           when(mockCacheService.isDeclarationAmendable(any(), any())(any())).thenReturn(Future.successful(true))
 
           val departureDeclarationErrorsP5ViewModel = new DepartureDeclarationErrorsP5ViewModel(lrn.value, isAmendmentJourney = false)
@@ -89,7 +89,7 @@ class DepartureDeclarationErrorsP5ControllerSpec extends SpecBase with AppWithDe
               when(mockDepartureP5MessageService.getMessage[CC056CType](any(), any())(any(), any(), any()))
                 .thenReturn(Future.successful(message))
               when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-                .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+                .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
               when(mockCacheService.isDeclarationAmendable(any(), any())(any())).thenReturn(Future.successful(false))
 
               val request = FakeRequest(GET, departureDeclarationErrorsController)

--- a/test/controllers/departureP5/DepartureNotCancelledP5ControllerSpec.scala
+++ b/test/controllers/departureP5/DepartureNotCancelledP5ControllerSpec.scala
@@ -64,7 +64,7 @@ class DepartureNotCancelledP5ControllerSpec extends SpecBase with AppWithDefault
             new DepartureNotCancelledP5ViewModel(sections, departureIdP5, lrn.toString)
 
           when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-            .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+            .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
           when(mockDepartureP5MessageService.getMessage[CC009CType](any(), any())(any(), any(), any())).thenReturn(Future.successful(message))
           when(mockDepartureNotCancelledP5ViewModelProvider.apply(any(), any(), any())(any(), any(), any()))
             .thenReturn(Future.successful(departureNotCancelledP5ViewModel))

--- a/test/controllers/departureP5/GoodsNotReleasedP5ControllerSpec.scala
+++ b/test/controllers/departureP5/GoodsNotReleasedP5ControllerSpec.scala
@@ -65,7 +65,7 @@ class GoodsNotReleasedP5ControllerSpec extends SpecBase with AppWithDefaultMockF
         message =>
           when(mockDepartureP5MessageService.getMessage[CC051CType](any(), any())(any(), any(), any())).thenReturn(Future.successful(message))
           when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-            .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+            .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
           when(mockGoodsNotReleasedP5ViewModelProvider.apply(any(), any())(any())).thenReturn(goodsNotReleasedP5ViewModel)
 
           val request = FakeRequest(GET, routes)

--- a/test/controllers/departureP5/GoodsUnderControlIndexControllerSpec.scala
+++ b/test/controllers/departureP5/GoodsUnderControlIndexControllerSpec.scala
@@ -62,7 +62,7 @@ class GoodsUnderControlIndexControllerSpec extends SpecBase with ScalaCheckPrope
         message =>
           when(mockDepartureP5MessageService.getMessage[CC060CType](any(), any())(any(), any(), any())).thenReturn(Future.successful(message))
           when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-            .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+            .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
 
           val request = FakeRequest(GET, controllers.departureP5.routes.GoodsUnderControlIndexController.onPageLoad(departureIdP5, messageId).url)
 
@@ -82,7 +82,7 @@ class GoodsUnderControlIndexControllerSpec extends SpecBase with ScalaCheckPrope
         message =>
           when(mockDepartureP5MessageService.getMessage[CC060CType](any(), any())(any(), any(), any())).thenReturn(Future.successful(message))
           when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-            .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+            .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
           when(mockReferenceDataService.getCustomsOffice(any())(any(), any())).thenReturn(Future.successful(Right(customsOffice)))
 
           val request = FakeRequest(GET, controllers.departureP5.routes.GoodsUnderControlIndexController.onPageLoad(departureIdP5, messageId).url)
@@ -105,7 +105,7 @@ class GoodsUnderControlIndexControllerSpec extends SpecBase with ScalaCheckPrope
         message =>
           when(mockDepartureP5MessageService.getMessage[CC060CType](any(), any())(any(), any(), any())).thenReturn(Future.successful(message))
           when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-            .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+            .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
 
           val request = FakeRequest(GET, controllers.departureP5.routes.GoodsUnderControlIndexController.onPageLoad(departureIdP5, messageId).url)
 
@@ -132,7 +132,7 @@ class GoodsUnderControlIndexControllerSpec extends SpecBase with ScalaCheckPrope
             message =>
               when(mockDepartureP5MessageService.getMessage[CC060CType](any(), any())(any(), any(), any())).thenReturn(Future.successful(message))
               when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-                .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+                .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
 
               val request = FakeRequest(GET, controllers.departureP5.routes.GoodsUnderControlIndexController.onPageLoad(departureIdP5, messageId).url)
 

--- a/test/controllers/departureP5/GoodsUnderControlP5ControllerSpec.scala
+++ b/test/controllers/departureP5/GoodsUnderControlP5ControllerSpec.scala
@@ -72,7 +72,7 @@ class GoodsUnderControlP5ControllerSpec extends SpecBase with AppWithDefaultMock
 
               when(mockDepartureP5MessageService.getMessage[CC060CType](any(), any())(any(), any(), any())).thenReturn(Future.successful(message))
               when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-                .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+                .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
               when(mockReferenceDataService.getCustomsOffice(any())(any(), any())).thenReturn(Future.successful(Right(customsOffice)))
               when(mockGoodsUnderControlP5ViewModelProvider.apply(any())(any(), any(), any()))
                 .thenReturn(Future.successful(GoodsUnderControlP5ViewModel(sections, requestedDocuments = true, Some(lrn.toString))))
@@ -102,7 +102,7 @@ class GoodsUnderControlP5ControllerSpec extends SpecBase with AppWithDefaultMock
 
           when(mockDepartureP5MessageService.getMessage[CC060CType](any(), any())(any(), any(), any())).thenReturn(Future.successful(message))
           when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-            .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+            .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
           when(mockReferenceDataService.getCustomsOffice(any())(any(), any())).thenReturn(Future.successful(Right(customsOffice)))
           when(mockGoodsUnderControlP5ViewModelProvider.apply(any())(any(), any(), any()))
             .thenReturn(Future.successful(GoodsUnderControlP5ViewModel(sections, requestedDocuments = false, Some(lrn.toString))))

--- a/test/controllers/departureP5/GuaranteeRejectedP5ControllerSpec.scala
+++ b/test/controllers/departureP5/GuaranteeRejectedP5ControllerSpec.scala
@@ -54,7 +54,7 @@ class GuaranteeRejectedP5ControllerSpec extends SpecBase with AppWithDefaultMock
 
   "GuaranteeRejected" - {
 
-    lazy val controller = routes.GuaranteeRejectedP5Controller.onPageLoad(departureIdP5, messageId, lrn).url
+    lazy val controller = routes.GuaranteeRejectedP5Controller.onPageLoad(departureIdP5, messageId).url
 
     "onPageLoad" - {
 
@@ -65,13 +65,13 @@ class GuaranteeRejectedP5ControllerSpec extends SpecBase with AppWithDefaultMock
               .thenReturn(Future.successful(message))
 
             when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-              .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+              .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
 
             when(mockDepartureCacheConnector.doesDeclarationExist(any())(any())) thenReturn Future.successful(true)
 
             val viewModel = GuaranteeRejectedP5ViewModel(
               guaranteeReferences = message.GuaranteeReference,
-              lrn = lrn,
+              lrn = lrn.value,
               isAmendable = true,
               mrn = message.TransitOperation.MRN,
               acceptanceDate = message.TransitOperation.declarationAcceptanceDate
@@ -93,7 +93,7 @@ class GuaranteeRejectedP5ControllerSpec extends SpecBase with AppWithDefaultMock
 
     "onAmend" - {
 
-      lazy val controller = routes.GuaranteeRejectedP5Controller.onAmend(departureIdP5, messageId, lrn).url
+      lazy val controller = routes.GuaranteeRejectedP5Controller.onAmend(departureIdP5, messageId).url
 
       "must redirect to NewLocalReferenceNumber page on success" in {
         forAll(arbitrary[CC055CType]) {
@@ -102,7 +102,7 @@ class GuaranteeRejectedP5ControllerSpec extends SpecBase with AppWithDefaultMock
               .thenReturn(Future.successful(message))
 
             when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-              .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+              .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
 
             when(mockDepartureCacheConnector.handleGuaranteeRejection(any())(any())) thenReturn Future.successful(true)
 
@@ -122,7 +122,7 @@ class GuaranteeRejectedP5ControllerSpec extends SpecBase with AppWithDefaultMock
               .thenReturn(Future.successful(message))
 
             when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-              .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+              .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
 
             when(mockDepartureCacheConnector.handleGuaranteeRejection(any())(any())) thenReturn Future.successful(false)
 

--- a/test/controllers/departureP5/IntentionToControlP5ControllerSpec.scala
+++ b/test/controllers/departureP5/IntentionToControlP5ControllerSpec.scala
@@ -72,7 +72,7 @@ class IntentionToControlP5ControllerSpec extends SpecBase with AppWithDefaultMoc
 
               when(mockDepartureP5MessageService.getMessage[CC060CType](any(), any())(any(), any(), any())).thenReturn(Future.successful(message))
               when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-                .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+                .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
               when(mockReferenceDataService.getCustomsOffice(any())(any(), any())).thenReturn(Future.successful(Right(customsOffice)))
               when(mockIntentionToControlP5ViewModelProvider.apply(any())(any()))
                 .thenReturn(IntentionToControlP5ViewModel(sections, requestedDocuments = true, Some(lrn.toString)))
@@ -104,7 +104,7 @@ class IntentionToControlP5ControllerSpec extends SpecBase with AppWithDefaultMoc
 
           when(mockDepartureP5MessageService.getMessage[CC060CType](any(), any())(any(), any(), any())).thenReturn(Future.successful(message))
           when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-            .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+            .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
           when(mockReferenceDataService.getCustomsOffice(any())(any(), any())).thenReturn(Future.successful(Right(customsOffice)))
           when(mockIntentionToControlP5ViewModelProvider.apply(any())(any()))
             .thenReturn(IntentionToControlP5ViewModel(sections, requestedDocuments = false, Some(lrn.toString)))

--- a/test/controllers/departureP5/RecoveryNotificationControllerSpec.scala
+++ b/test/controllers/departureP5/RecoveryNotificationControllerSpec.scala
@@ -65,7 +65,7 @@ class RecoveryNotificationControllerSpec extends SpecBase with AppWithDefaultMoc
         message =>
           when(mockDepartureP5MessageService.getMessage[CC035CType](any(), any())(any(), any(), any())).thenReturn(Future.successful(message))
           when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-            .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+            .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
           when(mockRecoveryNotificationViewModelProvider.apply(any())(any())).thenReturn(recoveryNotificationViewModel)
 
           val request = FakeRequest(GET, routes)
@@ -77,7 +77,7 @@ class RecoveryNotificationControllerSpec extends SpecBase with AppWithDefaultMoc
           val view = injector.instanceOf[RecoveryNotificationView]
 
           contentAsString(result) mustEqual
-            view(recoveryNotificationViewModel, lrn)(request, messages).toString
+            view(recoveryNotificationViewModel, lrn.value)(request, messages).toString
       }
     }
   }

--- a/test/controllers/departureP5/RejectionMessageP5ControllerSpec.scala
+++ b/test/controllers/departureP5/RejectionMessageP5ControllerSpec.scala
@@ -85,7 +85,7 @@ class RejectionMessageP5ControllerSpec extends SpecBase with AppWithDefaultMockF
               when(mockDepartureP5MessageService.getMessage[CC056CType](any(), any())(any(), any(), any()))
                 .thenReturn(Future.successful(message))
               when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-                .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+                .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
               when(mockCacheService.isDeclarationAmendable(any(), any())(any())).thenReturn(Future.successful(true))
               when(mockRejectionMessageP5ViewModelProvider.apply(any(), any(), any())(any(), any(), any()))
                 .thenReturn(Future.successful(RejectionMessageP5ViewModel(Seq(Seq(tableRow)), lrn.toString, multipleErrors = true, isAmendmentJourney = false)))
@@ -129,7 +129,7 @@ class RejectionMessageP5ControllerSpec extends SpecBase with AppWithDefaultMockF
               when(mockDepartureP5MessageService.getMessage[CC056CType](any(), any())(any(), any(), any()))
                 .thenReturn(Future.successful(message))
               when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-                .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+                .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
               when(mockCacheService.doesDeclarationExist(any())(any())).thenReturn(Future.successful(true))
               when(mockRejectionMessageP5ViewModelProvider.apply(any(), any(), any())(any(), any(), any()))
                 .thenReturn(Future.successful(RejectionMessageP5ViewModel(Seq(Seq(tableRow)), lrn.toString, multipleErrors = true, isAmendmentJourney = true)))
@@ -173,7 +173,7 @@ class RejectionMessageP5ControllerSpec extends SpecBase with AppWithDefaultMockF
               when(mockDepartureP5MessageService.getMessage[CC056CType](any(), any())(any(), any(), any()))
                 .thenReturn(Future.successful(message))
               when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-                .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+                .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
               when(mockCacheService.doesDeclarationExist(any())(any())).thenReturn(Future.successful(true))
               when(mockRejectionMessageP5ViewModelProvider.apply(any(), any(), any())(any(), any(), any()))
                 .thenReturn(Future.successful(RejectionMessageP5ViewModel(Seq(Seq(tableRow)), lrn.toString, multipleErrors = true, isAmendmentJourney = true)))
@@ -215,7 +215,7 @@ class RejectionMessageP5ControllerSpec extends SpecBase with AppWithDefaultMockF
           when(mockDepartureP5MessageService.getMessage[CC056CType](any(), any())(any(), any(), any()))
             .thenReturn(Future.successful(message))
           when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-            .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+            .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
           when(mockCacheService.isDeclarationAmendable(any(), any())(any())).thenReturn(Future.successful(false))
 
           val request = FakeRequest(GET, rejectionMessageController)
@@ -233,7 +233,7 @@ class RejectionMessageP5ControllerSpec extends SpecBase with AppWithDefaultMockF
           when(mockDepartureP5MessageService.getMessage[CC056CType](any(), any())(any(), any(), any()))
             .thenReturn(Future.successful(message))
           when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-            .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+            .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
           when(mockCacheService.doesDeclarationExist(any())(any())).thenReturn(Future.successful(false))
 
           val request = FakeRequest(GET, rejectionMessageAmendmentController)
@@ -252,7 +252,7 @@ class RejectionMessageP5ControllerSpec extends SpecBase with AppWithDefaultMockF
           message =>
             when(mockDepartureP5MessageService.getMessage[CC056CType](any(), any())(any(), any(), any())).thenReturn(Future.successful(message))
             when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-              .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+              .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
             when(mockCacheService.isDeclarationAmendable(any(), any())(any())).thenReturn(Future.successful(false))
             when(mockCacheService.handleErrors(any(), any())(any())).thenReturn(Future.successful(true))
 
@@ -270,7 +270,7 @@ class RejectionMessageP5ControllerSpec extends SpecBase with AppWithDefaultMockF
           message =>
             when(mockDepartureP5MessageService.getMessage[CC056CType](any(), any())(any(), any(), any())).thenReturn(Future.successful(message))
             when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-              .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+              .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
             when(mockCacheService.isDeclarationAmendable(any(), any())(any())).thenReturn(Future.successful(true))
             when(mockCacheService.handleErrors(any(), any())(any())).thenReturn(Future.successful(true))
             when(mockCacheService.doesDeclarationExist(any())(any())).thenReturn(Future.successful(true))
@@ -296,7 +296,7 @@ class RejectionMessageP5ControllerSpec extends SpecBase with AppWithDefaultMockF
               message =>
                 when(mockDepartureP5MessageService.getMessage[CC056CType](any(), any())(any(), any(), any())).thenReturn(Future.successful(message))
                 when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-                  .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+                  .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
                 when(mockCacheService.isDeclarationAmendable(any(), any())(any())).thenReturn(Future.successful(true))
                 when(mockCacheService.handleErrors(any(), any())(any())).thenReturn(Future.successful(true))
 
@@ -315,7 +315,7 @@ class RejectionMessageP5ControllerSpec extends SpecBase with AppWithDefaultMockF
           message =>
             when(mockDepartureP5MessageService.getMessage[CC056CType](any(), any())(any(), any(), any())).thenReturn(Future.successful(message))
             when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-              .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+              .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
             when(mockCacheService.handleAmendmentErrors(any(), any())(any())).thenReturn(Future.successful(true))
             when(mockCacheService.doesDeclarationExist(any())(any())).thenReturn(Future.successful(true))
 
@@ -342,7 +342,7 @@ class RejectionMessageP5ControllerSpec extends SpecBase with AppWithDefaultMockF
                 when(mockCacheService.handleErrors(any(), any())(any())).thenReturn(Future.successful(true))
                 when(mockDepartureP5MessageService.getMessage[CC056CType](any(), any())(any(), any(), any())).thenReturn(Future.successful(message))
                 when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-                  .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, Some(mrn))))
+                  .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, Some(mrn))))
                 when(mockCacheService.doesDeclarationExist(any())(any())).thenReturn(Future.successful(true))
 
                 val request = FakeRequest(POST, rejectionMessageOnAmend)
@@ -360,7 +360,7 @@ class RejectionMessageP5ControllerSpec extends SpecBase with AppWithDefaultMockF
           message =>
             when(mockDepartureP5MessageService.getMessage[CC056CType](any(), any())(any(), any(), any())).thenReturn(Future.successful(message))
             when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-              .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+              .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
             when(mockCacheService.isDeclarationAmendable(any(), any())(any())).thenReturn(Future.successful(true))
             when(mockCacheService.handleErrors(any(), any())(any())).thenReturn(Future.successful(false))
             when(mockCacheService.doesDeclarationExist(any())(any())).thenReturn(Future.successful(true))

--- a/test/controllers/departureP5/ReviewCancellationErrorsP5ControllerSpec.scala
+++ b/test/controllers/departureP5/ReviewCancellationErrorsP5ControllerSpec.scala
@@ -75,7 +75,7 @@ class ReviewCancellationErrorsP5ControllerSpec extends SpecBase with AppWithDefa
               when(mockDepartureP5MessageService.getMessage[CC056CType](any(), any())(any(), any(), any()))
                 .thenReturn(Future.successful(message))
               when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-                .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+                .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
               when(mockCacheService.isDeclarationAmendable(any(), any())(any())).thenReturn(Future.successful(true))
               when(mockReviewDepartureErrorMessageP5ViewModelProvider.apply(any(), any())(any(), any(), any()))
                 .thenReturn(Future.successful(ReviewCancellationErrorsP5ViewModel(Seq(Seq(tableRow)), lrn.toString, multipleErrors = true)))

--- a/test/controllers/departureP5/ReviewDepartureErrorsP5ControllerSpec.scala
+++ b/test/controllers/departureP5/ReviewDepartureErrorsP5ControllerSpec.scala
@@ -75,7 +75,7 @@ class ReviewDepartureErrorsP5ControllerSpec extends SpecBase with AppWithDefault
               when(mockDepartureP5MessageService.getMessage[CC056CType](any(), any())(any(), any(), any()))
                 .thenReturn(Future.successful(message))
               when(mockDepartureP5MessageService.getDepartureReferenceNumbers(any())(any(), any()))
-                .thenReturn(Future.successful(DepartureReferenceNumbers(lrn, None)))
+                .thenReturn(Future.successful(DepartureReferenceNumbers(lrn.value, None)))
               when(mockCacheService.isDeclarationAmendable(any(), any())(any())).thenReturn(Future.successful(true))
               when(mockReviewDepartureErrorMessageP5ViewModelProvider.apply(any(), any(), any())(any(), any(), any()))
                 .thenReturn(

--- a/test/controllers/departureP5/drafts/DeleteDraftDepartureYesNoControllerSpec.scala
+++ b/test/controllers/departureP5/drafts/DeleteDraftDepartureYesNoControllerSpec.scala
@@ -38,8 +38,6 @@ class DeleteDraftDepartureYesNoControllerSpec extends SpecBase with AppWithDefau
   private val formProvider = new YesNoFormProvider()
   private val form         = formProvider("departure.drafts.deleteDraftDepartureYesNo")
 
-  val lrnString: String = lrn.toString()
-
   private val draftDepartureService = mock[DraftDepartureService]
 
   final val mockLockActionProvider: LockActionProvider = mock[LockActionProvider]
@@ -68,7 +66,7 @@ class DeleteDraftDepartureYesNoControllerSpec extends SpecBase with AppWithDefau
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form, lrnString, 1, 2, None)(request, messages).toString
+        view(form, lrn, 1, 2, None)(request, messages).toString
     }
 
     "when yes submitted must redirect back to draft departure dashboard when on first page" in {
@@ -159,8 +157,6 @@ class DeleteDraftDepartureYesNoControllerSpec extends SpecBase with AppWithDefau
 
     "must return a Bad Request and errors when invalid data is submitted" in {
 
-      val lrnString = lrn.toString
-
       val invalidValue = ""
       val request      = FakeRequest(POST, deleteDraftDepartureYesNoRoute).withFormUrlEncodedBody(("value", invalidValue))
       val boundForm    = form.bind(Map("value" -> invalidValue))
@@ -174,7 +170,7 @@ class DeleteDraftDepartureYesNoControllerSpec extends SpecBase with AppWithDefau
       val content = contentAsString(result)
 
       content mustEqual
-        view(boundForm, lrnString, 1, 2, None)(request, messages).toString
+        view(boundForm, lrn, 1, 2, None)(request, messages).toString
     }
 
   }

--- a/test/generators/ModelGenerators.scala
+++ b/test/generators/ModelGenerators.scala
@@ -259,7 +259,7 @@ trait ModelGenerators {
         mrn         <- arbitrary[String]
         lrn         <- arbitrary[LocalReferenceNumber]
         updated     <- arbitrary[LocalDateTime]
-      } yield DepartureMovement(departureId, Some(mrn), lrn, updated)
+      } yield DepartureMovement(departureId, Some(mrn), lrn.value, updated)
     }
 
   implicit lazy val arbitraryDepartureMovements: Arbitrary[DepartureMovements] =

--- a/test/models/departureP5/DepartureMovementSpec.scala
+++ b/test/models/departureP5/DepartureMovementSpec.scala
@@ -17,7 +17,6 @@
 package models.departureP5
 
 import base.SpecBase
-import models.LocalReferenceNumber
 import play.api.libs.json._
 
 import java.time.LocalDateTime
@@ -51,7 +50,7 @@ class DepartureMovementSpec extends SpecBase {
       val expectedResult = DepartureMovement(
         "63651574c3447b12",
         Some("27WF9X1FQ9RCKN0TM3"),
-        LocalReferenceNumber("AB123"),
+        "AB123",
         LocalDateTime.parse("2022-11-04T13:36:52.332Z", DateTimeFormatter.ISO_DATE_TIME)
       )
 

--- a/test/models/departureP5/DepartureMovementsSpec.scala
+++ b/test/models/departureP5/DepartureMovementsSpec.scala
@@ -17,7 +17,6 @@
 package models.departureP5
 
 import base.SpecBase
-import models.LocalReferenceNumber
 import play.api.libs.json.Json
 
 import java.time.LocalDateTime
@@ -83,13 +82,13 @@ class DepartureMovementsSpec extends SpecBase {
           DepartureMovement(
             "63651574c3447b12",
             Some("27WF9X1FQ9RCKN0TM3"),
-            LocalReferenceNumber("AB123"),
+            "AB123",
             LocalDateTime.parse("2022-11-04T13:36:52.332Z", DateTimeFormatter.ISO_DATE_TIME)
           ),
           DepartureMovement(
             "6365135ba5e821ee",
             Some("27WF9X1FQ9RCKN0TM3"),
-            LocalReferenceNumber("CD123"),
+            "CD123",
             LocalDateTime.parse("2022-11-04T13:27:55.522Z", DateTimeFormatter.ISO_DATE_TIME)
           )
         ),

--- a/test/services/DepartureP5MessageServiceSpec.scala
+++ b/test/services/DepartureP5MessageServiceSpec.scala
@@ -70,7 +70,7 @@ class DepartureP5MessageServiceSpec extends SpecBase with Generators {
             DepartureMovement(
               "AB123",
               Some("MRN"),
-              LocalReferenceNumber("LRN"),
+              "LRN",
               dateTimeNow
             )
           ),
@@ -103,7 +103,7 @@ class DepartureP5MessageServiceSpec extends SpecBase with Generators {
         val expectedResult: Seq[MovementAndMessage] = Seq(
           RejectedMovementAndMessage(
             "AB123",
-            LocalReferenceNumber("LRN"),
+            "LRN",
             dateTimeNow,
             latestDepartureMessage,
             rejectionType,
@@ -134,7 +134,7 @@ class DepartureP5MessageServiceSpec extends SpecBase with Generators {
             DepartureMovement(
               "AB123",
               Some("MRN"),
-              LocalReferenceNumber("LRN"),
+              "LRN",
               dateTimeNow
             )
           ),
@@ -156,7 +156,7 @@ class DepartureP5MessageServiceSpec extends SpecBase with Generators {
         val expectedResult: Seq[MovementAndMessage] = Seq(
           DepartureMovementAndMessage(
             "AB123",
-            LocalReferenceNumber("LRN"),
+            "LRN",
             dateTimeNow,
             latestDepartureMessage,
             ie015.isPreLodged
@@ -193,7 +193,7 @@ class DepartureP5MessageServiceSpec extends SpecBase with Generators {
                   DepartureMovement(
                     "AB123",
                     Some("MRN"),
-                    LocalReferenceNumber("LRN"),
+                    "LRN",
                     dateTimeNow
                   )
                 ),
@@ -215,7 +215,7 @@ class DepartureP5MessageServiceSpec extends SpecBase with Generators {
               val expectedResult: Seq[MovementAndMessage] = Seq(
                 OtherMovementAndMessage(
                   "AB123",
-                  LocalReferenceNumber("LRN"),
+                  "LRN",
                   dateTimeNow,
                   latestDepartureMessage
                 )

--- a/test/viewModels/P5/DepartureStatusP5ViewModelSpec.scala
+++ b/test/viewModels/P5/DepartureStatusP5ViewModelSpec.scala
@@ -33,7 +33,7 @@ class DepartureStatusP5ViewModelSpec extends SpecBase with Generators with Scala
     def otherMovementAndMessage(messageType: DepartureMessageType): OtherMovementAndMessage =
       OtherMovementAndMessage(
         departureIdP5,
-        lrn,
+        lrn.value,
         LocalDateTime.now(),
         LatestDepartureMessage(
           DepartureMessage(
@@ -145,7 +145,7 @@ class DepartureStatusP5ViewModelSpec extends SpecBase with Generators with Scala
 
         val movementAndMessage = DepartureMovementAndMessage(
           departureIdP5,
-          lrn,
+          lrn.value,
           LocalDateTime.now(),
           LatestDepartureMessage(
             DepartureMessage(
@@ -185,7 +185,7 @@ class DepartureStatusP5ViewModelSpec extends SpecBase with Generators with Scala
 
         val movementAndMessage = DepartureMovementAndMessage(
           departureIdP5,
-          lrn,
+          lrn.value,
           LocalDateTime.now(),
           LatestDepartureMessage(
             DepartureMessage(
@@ -266,7 +266,7 @@ class DepartureStatusP5ViewModelSpec extends SpecBase with Generators with Scala
 
       val movementAndMessage = OtherMovementAndMessage(
         departureIdP5,
-        lrn,
+        lrn.value,
         LocalDateTime.now(),
         LatestDepartureMessage(
           DepartureMessage(
@@ -345,7 +345,7 @@ class DepartureStatusP5ViewModelSpec extends SpecBase with Generators with Scala
         "movement.status.P5.guaranteeRejected",
         Seq(
           ViewMovementAction(
-            controllers.departureP5.routes.GuaranteeRejectedP5Controller.onPageLoad(departureIdP5, messageId, lrn).url,
+            controllers.departureP5.routes.GuaranteeRejectedP5Controller.onPageLoad(departureIdP5, messageId).url,
             "movement.status.P5.action.guaranteeRejected.viewErrors"
           ),
           ViewMovementAction(
@@ -366,7 +366,7 @@ class DepartureStatusP5ViewModelSpec extends SpecBase with Generators with Scala
 
           val movementAndMessage = RejectedMovementAndMessage(
             departureIdP5,
-            lrn,
+            lrn.value,
             LocalDateTime.now(),
             LatestDepartureMessage(
               DepartureMessage(
@@ -401,7 +401,7 @@ class DepartureStatusP5ViewModelSpec extends SpecBase with Generators with Scala
 
           val movementAndMessage = RejectedMovementAndMessage(
             departureIdP5,
-            lrn,
+            lrn.value,
             LocalDateTime.now(),
             LatestDepartureMessage(
               DepartureMessage(
@@ -436,7 +436,7 @@ class DepartureStatusP5ViewModelSpec extends SpecBase with Generators with Scala
 
           val movementAndMessage = RejectedMovementAndMessage(
             departureIdP5,
-            lrn,
+            lrn.value,
             LocalDateTime.now(),
             LatestDepartureMessage(
               DepartureMessage(
@@ -471,7 +471,7 @@ class DepartureStatusP5ViewModelSpec extends SpecBase with Generators with Scala
 
           val movementAndMessage = RejectedMovementAndMessage(
             departureIdP5,
-            lrn,
+            lrn.value,
             LocalDateTime.now(),
             LatestDepartureMessage(
               DepartureMessage(
@@ -512,7 +512,7 @@ class DepartureStatusP5ViewModelSpec extends SpecBase with Generators with Scala
         "and declaration is amendable" in {
           val movementAndMessage = RejectedMovementAndMessage(
             departureIdP5,
-            lrn,
+            lrn.value,
             LocalDateTime.now(),
             LatestDepartureMessage(
               DepartureMessage(
@@ -546,7 +546,7 @@ class DepartureStatusP5ViewModelSpec extends SpecBase with Generators with Scala
         "and declaration is not amendable with errors in range 2 to 10" in {
           val movementAndMessage = RejectedMovementAndMessage(
             departureIdP5,
-            lrn,
+            lrn.value,
             LocalDateTime.now(),
             LatestDepartureMessage(
               DepartureMessage(
@@ -580,7 +580,7 @@ class DepartureStatusP5ViewModelSpec extends SpecBase with Generators with Scala
         "and declaration is not amendable with one error" in {
           val movementAndMessage = RejectedMovementAndMessage(
             departureIdP5,
-            lrn,
+            lrn.value,
             LocalDateTime.now(),
             LatestDepartureMessage(
               DepartureMessage(
@@ -614,7 +614,7 @@ class DepartureStatusP5ViewModelSpec extends SpecBase with Generators with Scala
         "and declaration is not amendable and no FunctionalErrors" in {
           val movementAndMessage = RejectedMovementAndMessage(
             departureIdP5,
-            lrn,
+            lrn.value,
             LocalDateTime.now(),
             LatestDepartureMessage(
               DepartureMessage(
@@ -653,7 +653,7 @@ class DepartureStatusP5ViewModelSpec extends SpecBase with Generators with Scala
         "with errors in range 2 to 10" in {
           val movementAndMessage = RejectedMovementAndMessage(
             departureIdP5,
-            lrn,
+            lrn.value,
             LocalDateTime.now(),
             LatestDepartureMessage(
               DepartureMessage(
@@ -687,7 +687,7 @@ class DepartureStatusP5ViewModelSpec extends SpecBase with Generators with Scala
         "with one error " in {
           val movementAndMessage = RejectedMovementAndMessage(
             departureIdP5,
-            lrn,
+            lrn.value,
             LocalDateTime.now(),
             LatestDepartureMessage(
               DepartureMessage(
@@ -721,7 +721,7 @@ class DepartureStatusP5ViewModelSpec extends SpecBase with Generators with Scala
         "with no FunctionalErrors" in {
           val movementAndMessage = RejectedMovementAndMessage(
             departureIdP5,
-            lrn,
+            lrn.value,
             LocalDateTime.now(),
             LatestDepartureMessage(
               DepartureMessage(
@@ -762,7 +762,7 @@ class DepartureStatusP5ViewModelSpec extends SpecBase with Generators with Scala
 
         val movementAndMessage = DepartureMovementAndMessage(
           departureIdP5,
-          lrn,
+          lrn.value,
           LocalDateTime.now(),
           LatestDepartureMessage(
             DepartureMessage(
@@ -802,7 +802,7 @@ class DepartureStatusP5ViewModelSpec extends SpecBase with Generators with Scala
 
         val movementAndMessage = DepartureMovementAndMessage(
           departureIdP5,
-          lrn,
+          lrn.value,
           LocalDateTime.now(),
           LatestDepartureMessage(
             DepartureMessage(
@@ -855,7 +855,7 @@ class DepartureStatusP5ViewModelSpec extends SpecBase with Generators with Scala
 
         val movementAndMessage = DepartureMovementAndMessage(
           departureIdP5,
-          lrn,
+          lrn.value,
           LocalDateTime.now(),
           LatestDepartureMessage(
             DepartureMessage(
@@ -895,7 +895,7 @@ class DepartureStatusP5ViewModelSpec extends SpecBase with Generators with Scala
 
         val movementAndMessage = DepartureMovementAndMessage(
           departureIdP5,
-          lrn,
+          lrn.value,
           LocalDateTime.now(),
           LatestDepartureMessage(
             DepartureMessage(

--- a/test/views/departureP5/GuaranteeRejectedP5ViewSpec.scala
+++ b/test/views/departureP5/GuaranteeRejectedP5ViewSpec.scala
@@ -37,7 +37,7 @@ class GuaranteeRejectedP5ViewSpec extends ViewBehaviours with Generators {
 
   val defaultViewModel: GuaranteeRejectedP5ViewModel = GuaranteeRejectedP5ViewModel(
     guaranteeReferences = guaranteeReferences,
-    lrn = lrn,
+    lrn = lrn.value,
     isAmendable = true,
     mrn = mrn,
     acceptanceDate = XMLCalendar("2022-07-15")

--- a/test/views/departureP5/RecoveryNotificationViewSpec.scala
+++ b/test/views/departureP5/RecoveryNotificationViewSpec.scala
@@ -33,7 +33,7 @@ class RecoveryNotificationViewSpec extends CheckYourAnswersViewBehaviours with G
   override def viewWithSections(sections: Seq[Section]): HtmlFormat.Appendable =
     injector
       .instanceOf[RecoveryNotificationView]
-      .apply(recoveryNotificationViewModel, lrn)(fakeRequest, messages)
+      .apply(recoveryNotificationViewModel, lrn.value)(fakeRequest, messages)
 
   override def summaryLists: Seq[SummaryList] = sections.map(
     section => SummaryList(section.rows)

--- a/test/views/departureP5/drafts/DeleteDraftDepartureYesNoViewSpec.scala
+++ b/test/views/departureP5/drafts/DeleteDraftDepartureYesNoViewSpec.scala
@@ -27,7 +27,7 @@ import views.html.departureP5.drafts.DeleteDraftDepartureYesNoView
 class DeleteDraftDepartureYesNoViewSpec extends YesNoViewBehaviours with ScalaCheckPropertyChecks {
 
   override def applyView(form: Form[Boolean]): HtmlFormat.Appendable =
-    injector.instanceOf[DeleteDraftDepartureYesNoView].apply(form, lrn.toString(), 1, 1, None)(fakeRequest, messages)
+    injector.instanceOf[DeleteDraftDepartureYesNoView].apply(form, lrn, 1, 1, None)(fakeRequest, messages)
 
   override val prefix: String = "departure.drafts.deleteDraftDepartureYesNo"
 


### PR DESCRIPTION
Reading in LRN as String from API

LRN regex is incredibly permissive, so easiest just to read in as a String

Delete drafts can carry on using our validation, as this should conform with the validation in the IE015 journey