### PR TITLE
Revert "CTCP-5674: Adding data-prevent-double-click to movement action links."

### DIFF
--- a/app/views/components/MovementsTable.scala.html
+++ b/app/views/components/MovementsTable.scala.html
@@ -31,7 +31,7 @@
 @links(row: ViewMovement) = {
   @row.actions.map { action =>
     <div>
-      <a id="@action.id(row.referenceNumber)" href="@action.href" class="govuk-link" data-module="button" role="button" data-prevent-double-click="true">@messages(action.key)
+      <a id="@action.id(row.referenceNumber)" href="@action.href" class="govuk-link">@messages(action.key)
         <span class="govuk-visually-hidden">@messages("viewArrivalNotifications.table.action.hidden", row.referenceNumber)</span>
       </a>
     </div>

--- a/test/connectors/ManageDocumentsConnectorSpec.scala
+++ b/test/connectors/ManageDocumentsConnectorSpec.scala
@@ -23,7 +23,7 @@ import helper.WireMockServerHandler
 import org.scalacheck.Gen
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.test.Helpers.running
+import play.api.test.Helpers.{running, ACCEPT}
 import uk.gov.hmrc.http.HttpResponse
 
 import scala.concurrent.Future

--- a/test/views/behaviours/MovementsTableViewBehaviours.scala
+++ b/test/views/behaviours/MovementsTableViewBehaviours.scala
@@ -107,12 +107,6 @@ trait MovementsTableViewBehaviours[T <: ViewMovement] extends ViewBehaviours wit
                       "must have correct href" in {
                         link.attr("href") mustBe action.href
                       }
-
-                      "must have 'prevent double click' attribute" in {
-                        link.attr("data-module") mustBe "button"
-                        link.attr("role") mustBe "button"
-                        link.attr("data-prevent-double-click") mustBe "true"
-                      }
                     }
                 }
               }


### PR DESCRIPTION
Reverts hmrc/manage-transit-movements-frontend#536